### PR TITLE
Added support for ZTE H288A and ZTE H196A

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ Component to integrate the ZTE H288A router as a device tracker in home assistan
 
 ## Example usage
 
-Place this fragment in configuration.yaml (adapting host, username and password) to your setup).
+To use this integration, place the following snippet in configuration.yaml. Be sure to change host, username and zte_password accordingly.
+
 
 ```
 # Setup the platform zte_tracker
@@ -22,3 +23,6 @@ zte_tracker:
      new_device_defaults:
        track_new_devices: no
 ```
+
+
+For more information about the device_tracker parameters visit the official [Home Assistant Documentation](https://www.home-assistant.io/integrations/device_tracker/)

--- a/README.md
+++ b/README.md
@@ -1,20 +1,27 @@
-# ZTE H288A Router Integration in Home Assistant (WORK IN PROGRESS)
-Component to integrate the ZTE H288A router as a device tracker in home assistant.
+# ZTE Router Integration for Home Assistant 
+Component to integrate ZTE routers as a device trackers in home assistant (Currently tested on models F6640 and H288A)
 
 ## Features
 - Provides a device_tracker to monitor the connection status of devices in your Wifi and LAN ports.
 - Exposes the status of the scanner in "sensor.zte_tracker".
 - Exposes the service "zte_tracker.pause" to pause/resume the scanner because when the scanner is running the web-admin-console sessions are cancelled.
 
+## Compatible routers
+- ZTE F6640
+- ZTE H288A
+
+This integration could work with more routers. Try one of the above and see if it work with yours.
+
 ## Example usage
 
-To use this integration, place the following snippet in configuration.yaml. Be sure to change host, username and zte_password accordingly.
+To use this integration, place the following snippet in configuration.yaml. 
 
 
 ```
 # Setup the platform zte_tracker
 zte_tracker:
      host: 192.168.1.1
+     device: F6640
      username: user
      password: !secret zte_password
      interval_seconds: 60
@@ -23,6 +30,18 @@ zte_tracker:
      new_device_defaults:
        track_new_devices: no
 ```
+Change the following parameters to match your configuration:
+
+`host`: Your router's local IP address (Usually 192.168.1.1)
+
+`username`: Your router's username (Usually admin)
+
+`password`: Your router's password 
+
+`device`: Your router's model. Chose one from the [list above](#compatible-routers) (without the ZTE in front) 
 
 
 For more information about the device_tracker parameters visit the official [Home Assistant Documentation](https://www.home-assistant.io/integrations/device_tracker/)
+
+
+[![hacs_badge](https://img.shields.io/badge/HACS-Custom-41BDF5.svg?style=for-the-badge)](https://github.com/hacs/integration)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ZTE H288A Router Integration in Home Assistant
+# ZTE H288A Router Integration in Home Assistant (WORK IN PROGRESS)
 Component to integrate the ZTE H288A router as a device tracker in home assistant.
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ZTE Router Integration for Home Assistant 
-Component to integrate ZTE routers as a device trackers in home assistant (Currently tested on models F6640 and H288A)
+Component to integrate some ZTE routers as a device trackers in home assistant.
 
 ## Features
 - Provides a device_tracker to monitor the connection status of devices in your Wifi and LAN ports.
@@ -7,12 +7,15 @@ Component to integrate ZTE routers as a device trackers in home assistant (Curre
 - Exposes the service "zte_tracker.pause" to pause/resume the scanner because when the scanner is running the web-admin-console sessions are cancelled.
 
 ## Compatible routers
-- ZTE F6640
-- ZTE H288A
+|   Name         | Model           | 
+| -------------  |:-------------:  | 
+| ZTE F6640      | F6640           |   
+| ZTE H288A      | H288A           | 
+| ZTE H169A      | H288A           |  
 
 This integration could work with more routers. Try one of the above and see if it work with yours.
 
-## Example usage
+## Installation
 
 To use this integration, place the following snippet in configuration.yaml. 
 
@@ -32,13 +35,13 @@ zte_tracker:
 ```
 Change the following parameters to match your configuration:
 
-`host`: Your router's local IP address (Usually 192.168.1.1)
+`host`: Your router's local IP address (Usually 192.168.1.1 or 192.168.0.1)
 
-`username`: Your router's username (Usually admin)
+`username`: Your router's login username (Usually admin)
 
-`password`: Your router's password 
+`password`: Your router's login password 
 
-`device`: Your router's model. Chose one from the [list above](#compatible-routers) (without the ZTE in front) 
+`device`: Your router's model. Chose one from the Model column of the [table above](#compatible-routers) 
 
 
 For more information about the device_tracker parameters visit the official [Home Assistant Documentation](https://www.home-assistant.io/integrations/device_tracker/)

--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
-# ZTE F6640 Router Integration in Home Assistant
-Component to integrate the Huawei ZTE router (tested on model ZTE F6640).
+# ZTE H288A Router Integration in Home Assistant
+Component to integrate the ZTE H288A router as a device tracker in home assistant.
 
 ## Features
 - Provides a device_tracker to monitor the connection status of devices in your Wifi and LAN ports.
 - Exposes the status of the scanner in "sensor.zte_tracker".
 - Exposes the service "zte_tracker.pause" to pause/resume the scanner because when the scanner is running the web-admin-console sessions are cancelled.
-- TODO: Publish the zte_tracker.reboot service to reboot the router (not implemented yet).
 
 ## Example usage
 
@@ -21,7 +20,5 @@ zte_tracker:
      consider_home: 180
      poll_time: 60
      new_device_defaults:
-       track_new_devices: false
+       track_new_devices: no
 ```
-
-[![hacs_badge](https://img.shields.io/badge/HACS-Custom-41BDF5.svg?style=for-the-badge)](https://github.com/hacs/integration)

--- a/custom_components/zte_tracker/__init__.py
+++ b/custom_components/zte_tracker/__init__.py
@@ -5,7 +5,7 @@ from .device_tracker import zteDeviceScanner
 
 import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
-from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
+from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME, CONF_DEVICE
 from homeassistant.helpers import discovery
 from homeassistant.core import HomeAssistant
 from homeassistant.config_entries import ConfigEntry
@@ -17,6 +17,7 @@ CONFIG_SCHEMA = vol.Schema({
         vol.Optional(CONF_USERNAME): cv.string,
         vol.Optional(CONF_PASSWORD): cv.string,
         vol.Optional(CONF_PASSWORD): cv.string,
+        vol.Optional(CONF_DEVICE): cv.string,
     }, extra=vol.ALLOW_EXTRA),
 }, extra=vol.ALLOW_EXTRA)
 
@@ -26,11 +27,12 @@ def setup(hass, config):
     """Set up is called when Home Assistant is loading our component."""
     plattform_conf = config.get(DOMAIN)
     _LOGGER.debug("Client initialized with {0}:{1}@{2}".format(
-        plattform_conf[CONF_USERNAME], plattform_conf[CONF_PASSWORD], plattform_conf[CONF_HOST]))
+        plattform_conf[CONF_USERNAME], plattform_conf[CONF_PASSWORD], plattform_conf[CONF_HOST],plattform_conf[CONF_DEVICE]))
 
     client = zteClient(plattform_conf[CONF_HOST],
                            plattform_conf[CONF_USERNAME],
-                           plattform_conf[CONF_PASSWORD])
+                           plattform_conf[CONF_PASSWORD],
+                           plattform_conf[CONF_DEVICE])
     scanner = zteDeviceScanner(hass, client)
 
     # Create DATA dict

--- a/custom_components/zte_tracker/__init__.py
+++ b/custom_components/zte_tracker/__init__.py
@@ -26,8 +26,8 @@ _LOGGER = logging.getLogger(__name__)
 def setup(hass, config):
     """Set up is called when Home Assistant is loading our component."""
     plattform_conf = config.get(DOMAIN)
-    _LOGGER.debug("Client initialized with {0}:{1}@{2}".format(
-        plattform_conf[CONF_USERNAME], plattform_conf[CONF_PASSWORD], plattform_conf[CONF_HOST],plattform_conf[CONF_DEVICE]))
+    _LOGGER.debug("Client initialized for ZTE {0} @{1}".format(plattform_conf[CONF_DEVICE]
+        , plattform_conf[CONF_HOST]))
 
     client = zteClient(plattform_conf[CONF_HOST],
                            plattform_conf[CONF_USERNAME],

--- a/custom_components/zte_tracker/__init__.py
+++ b/custom_components/zte_tracker/__init__.py
@@ -5,7 +5,7 @@ from .device_tracker import zteDeviceScanner
 
 import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
-from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME, CONF_DEVICE
+from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME, CONF_MODEL
 from homeassistant.helpers import discovery
 from homeassistant.core import HomeAssistant
 from homeassistant.config_entries import ConfigEntry
@@ -17,7 +17,7 @@ CONFIG_SCHEMA = vol.Schema({
         vol.Optional(CONF_USERNAME): cv.string,
         vol.Optional(CONF_PASSWORD): cv.string,
         vol.Optional(CONF_PASSWORD): cv.string,
-        vol.Optional(CONF_DEVICE): cv.string,
+        vol.Optional(CONF_MODEL): cv.string,
     }, extra=vol.ALLOW_EXTRA),
 }, extra=vol.ALLOW_EXTRA)
 
@@ -26,13 +26,13 @@ _LOGGER = logging.getLogger(__name__)
 def setup(hass, config):
     """Set up is called when Home Assistant is loading our component."""
     plattform_conf = config.get(DOMAIN)
-    _LOGGER.debug("Client initialized for ZTE {0} @{1}".format(plattform_conf[CONF_DEVICE]
+    _LOGGER.debug("Client initialized for ZTE {0} @{1}".format(plattform_conf[CONF_MODEL]
         , plattform_conf[CONF_HOST]))
 
     client = zteClient(plattform_conf[CONF_HOST],
                            plattform_conf[CONF_USERNAME],
                            plattform_conf[CONF_PASSWORD],
-                           plattform_conf[CONF_DEVICE])
+                           plattform_conf[CONF_MODEL])
     scanner = zteDeviceScanner(hass, client)
 
     # Create DATA dict

--- a/custom_components/zte_tracker/__init__.py
+++ b/custom_components/zte_tracker/__init__.py
@@ -12,12 +12,17 @@ from homeassistant.config_entries import ConfigEntry
 from .zteclient.zte_client import zteClient
 from .const import DOMAIN, PLATFORMS
 
+#Define models
+ACCEPTED_MODELS=['F6640','H288A']
+
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
         vol.Optional(CONF_USERNAME): cv.string,
         vol.Optional(CONF_PASSWORD): cv.string,
         vol.Optional(CONF_PASSWORD): cv.string,
-        vol.Optional(CONF_MODEL): cv.string,
+        vol.Optional(CONF_MODEL): vol.In(
+            ACCEPTED_MODELS
+        ),
     }, extra=vol.ALLOW_EXTRA),
 }, extra=vol.ALLOW_EXTRA)
 

--- a/custom_components/zte_tracker/zteclient/routers/F6640.txt
+++ b/custom_components/zte_tracker/zteclient/routers/F6640.txt
@@ -1,0 +1,2 @@
+wlan_client_stat_lua.lua&_=
+OBJ_WLAN_AD_ID

--- a/custom_components/zte_tracker/zteclient/routers/H288A.txt
+++ b/custom_components/zte_tracker/zteclient/routers/H288A.txt
@@ -1,0 +1,2 @@
+accessdev_ssiddev_lua.lua&_=
+OBJ_ACCESSDEV_ID

--- a/custom_components/zte_tracker/zteclient/zte_client.py
+++ b/custom_components/zte_tracker/zteclient/zte_client.py
@@ -8,7 +8,6 @@ from requests import Session
 import xml.etree.ElementTree as ET
 
 _LOGGER = logging.getLogger(__name__)
-accepted_devices = ['F6640', 'H288A']
 
 class zteClient:
     def __init__(self, host, username, password,model):

--- a/custom_components/zte_tracker/zteclient/zte_client.py
+++ b/custom_components/zte_tracker/zteclient/zte_client.py
@@ -152,9 +152,9 @@ class zteClient:
         # GET DEVICES RESPONSE
         try:
             r= self.session.get('http://{0}/?_type=menuView&_tag=localNetStatus&_={1}'.format(self.host, self.get_guid()),verify=False)
-            r= self.session.get('http://{0}/?_type=menuData&_tag=wlan_client_stat_lua.lua&_={1}'.format(self.host, self.get_guid()),verify=False)
+            r= self.session.get('http://{0}/?_type=menuData&_tag=accessdev_ssiddev_lua.lua&_={1}'.format(self.host, self.get_guid()),verify=False)
             self.log_request(r)
-            devices = self.parse_devices(r.text, 'OBJ_WLAN_AD_ID', 'WLAN')
+            devices = self.parse_devices(r.text, 'OBJ_ACCESSDEV_ID', 'WLAN')
             
             self.statusmsg = 'OK'
         except Exception as e:

--- a/custom_components/zte_tracker/zteclient/zte_client.py
+++ b/custom_components/zte_tracker/zteclient/zte_client.py
@@ -11,7 +11,7 @@ _LOGGER = logging.getLogger(__name__)
 accepted_devices = ['F6640', 'H288A']
 
 class zteClient:
-    def __init__(self, host, username, password,device):
+    def __init__(self, host, username, password,model):
         """Initialize the client."""
         self.statusmsg = None
         self.host = host
@@ -23,11 +23,13 @@ class zteClient:
         self.device_info = None
         self.guid = int(time.time()*1000)
 
-        if device in accepted_devices:
-            self.device = device
+        if model in accepted_devices:
+            self.model = model
         else:
-            self.device = 'F6640'
-        paths_file = open("/config/custom_components/zte_tracker/zteclient/routers/%s.txt" % device, "r")
+            _LOGGER.warning('Incompatible model {0}. Switching to default (F6640)'.format(model))
+            self.model = 'F6640'
+
+        paths_file = open("/config/custom_components/zte_tracker/zteclient/routers/%s.txt" % self.model, "r")
         self.paths = paths_file.read().splitlines()
         paths_file.close()
 

--- a/custom_components/zte_tracker/zteclient/zte_client.py
+++ b/custom_components/zte_tracker/zteclient/zte_client.py
@@ -7,11 +7,11 @@ import time
 from requests import Session
 import xml.etree.ElementTree as ET
 
-
 _LOGGER = logging.getLogger(__name__)
+accepted_devices = ['F6640', 'H288A']
 
 class zteClient:
-    def __init__(self, host, username, password):
+    def __init__(self, host, username, password,device):
         """Initialize the client."""
         self.statusmsg = None
         self.host = host
@@ -22,6 +22,14 @@ class zteClient:
         self.status = 'on'
         self.device_info = None
         self.guid = int(time.time()*1000)
+
+        if device in accepted_devices:
+            self.device = device
+        else:
+            self.device = 'F6640'
+        paths_file = open("/config/custom_components/zte_tracker/zteclient/routers/%s.txt" % device, "r")
+        self.paths = paths_file.read().splitlines()
+        paths_file.close()
 
     # REBOOT THE ROUTER
     def reboot(self) -> bool:
@@ -152,9 +160,9 @@ class zteClient:
         # GET DEVICES RESPONSE
         try:
             r= self.session.get('http://{0}/?_type=menuView&_tag=localNetStatus&_={1}'.format(self.host, self.get_guid()),verify=False)
-            r= self.session.get('http://{0}/?_type=menuData&_tag=accessdev_ssiddev_lua.lua&_={1}'.format(self.host, self.get_guid()),verify=False)
+            r= self.session.get('http://{0}/?_type=menuData&_tag={1}{2}'.format(self.host, self.paths[0],self.get_guid()),verify=False)
             self.log_request(r)
-            devices = self.parse_devices(r.text, 'OBJ_ACCESSDEV_ID', 'WLAN')
+            devices = self.parse_devices(r.text, '{0}'.format(self.paths[1]), 'WLAN')
             
             self.statusmsg = 'OK'
         except Exception as e:

--- a/custom_components/zte_tracker/zteclient/zte_client.py
+++ b/custom_components/zte_tracker/zteclient/zte_client.py
@@ -22,12 +22,7 @@ class zteClient:
         self.status = 'on'
         self.device_info = None
         self.guid = int(time.time()*1000)
-
-        if model in accepted_devices:
-            self.model = model
-        else:
-            _LOGGER.warning('Incompatible model {0}. Switching to default (F6640)'.format(model))
-            self.model = 'F6640'
+        self.model = model
 
         paths_file = open("/config/custom_components/zte_tracker/zteclient/routers/%s.txt" % self.model, "r")
         self.paths = paths_file.read().splitlines()


### PR DESCRIPTION
This is my first time contributing to a github repo, so please excuse any mistakes as I am not yet accustomed to the process.

## Why ZTE H288A was not working with the integration

My router is a ZTE H288A which has an interface similar to that of the ZTE F6640. The integration did not work by default. Upon inspecting the code and the requests on my router's web interface I found the issue was in this segment of code:
https://github.com/juacas/zte_tracker/blob/f614a653531603dd1fec1451baa3cd24125de96d/custom_components/zte_tracker/zteclient/zte_client.py#L155-L157

By changing:
 `wlan_client_stat_lua` to `accessdev_ssiddev_lua` and
`OBJ_WLAN_AD_ID` to `OBJ_ACCESSDEV_ID`
I was able to make the integration to work with my router.

## Changes to add support for it

- Home Assistant's configuration.yaml now requires an additional parameter named `model` with accepted values F6640 and H288A
- Created a new folder zte_tracker/zteclient/routers and added 2 files named F6640.txt and H288A.txt which contain the variable parts of the requests (see above). 
- The zteClient object now has 2 additional variables:
     -  `model`: the model name
     -  `paths`:  an array containing the variable parts of the requests. Values are inserted into this variable based on the model specified, by reading the .txt file with the same name.
- The strings that were problematic have the values from the paths array inserted into them when needed.

For example the string

 `'http://{0}/?_type=menuData&_tag=wlan_client_stat_lua.lua&_={1}'.format(self.host, self.get_guid())` 

is now

`'http://{0}/?_type=menuData&_tag={1}{2}'.format(self.host, self.paths[0],self.get_guid())`

## Other miscellaneous changes

**README.md**

- Added table for supported routers  
- Added more information about configuring the integration
- Improved wording


**__init__.py**

- Stopped transmitting router's username and password information in Home Assistant's logs 

## What has not been changed / tested

- I have not been able to test if the integration is still working with the ZTE F6640 router, you will have to test that 
- I have not edited any of the tests to include the `model` parameter

I hope my changes can be of help
