### PR TITLE
fix: import ScannerEntity from device_tracker root (deprecated in HA 2027.6)

### DIFF
--- a/custom_components/zte_tracker/device_tracker.py
+++ b/custom_components/zte_tracker/device_tracker.py
@@ -5,8 +5,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from homeassistant.components.device_tracker import SourceType
-from homeassistant.components.device_tracker.config_entry import ScannerEntity
+from homeassistant.components.device_tracker import ScannerEntity, SourceType
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr


### PR DESCRIPTION
## Summary

`ScannerEntity` is currently imported from `homeassistant.components.device_tracker.config_entry`, which Home Assistant core now exposes as a **`DeprecatedAlias`** scheduled for removal in **HA Core 2027.6**. On every startup HA logs:

> The deprecated alias `ScannerEntity` was used from `zte_tracker`. It will be removed in HA Core 2027.6. Use `homeassistant.components.device_tracker.ScannerEntity` instead.

## Change

Import `ScannerEntity` from the `device_tracker` package **root** (alongside the already-correct `SourceType`):

```diff
-from homeassistant.components.device_tracker import SourceType
-from homeassistant.components.device_tracker.config_entry import ScannerEntity
+from homeassistant.components.device_tracker import ScannerEntity, SourceType
```

This is the **same** `ScannerEntity` class (a connection/scanner entity — not the GPS-based `TrackerEntity`), so there is **no behavioural change**; only the import path is updated to the non-deprecated location. The root re-export has been available for a long time, so this is safe across supported HA versions.

## Testing

- `flake8 ... --max-line-length=88` -> 0 issues
- `black --check` -> unchanged
- `python -m py_compile` on all files -> OK
- JSON config files validate
- **Live HA instance**: `ha core check` passes; after restart all `device_tracker` entities continue to work and the `ScannerEntity` deprecation warning no longer appears.