### PR TITLE
Restore unconnected devices on reboot

### DIFF
--- a/custom_components/zte_tracker/device_tracker.py
+++ b/custom_components/zte_tracker/device_tracker.py
@@ -53,18 +53,29 @@ async def async_setup_entry(
         data = coordinator.data
         devices = data.get("devices", {})
 
-        entities = []
+        entities: list[ZteDeviceTrackerEntity] = []
         allow_new_devices = coordinator.register_new_devices
+
+        # Current entity objects in hass (entity_id -> entity object)
+        haentities = async_add_entities.__self__.entities
+
+        # IMPORTANT: ScannerEntity (homeassistant.components.device_tracker
+        # .config_entry.ScannerEntity) overrides the `unique_id` property to
+        # always return `self.mac_address`, regardless of what
+        # `self._attr_unique_id` is set to. So the *effective* unique_id for
+        # every entity here is simply the MAC address itself (as returned by
+        # `mac_address`) - never an entry_id-prefixed string. All matching
+        # below is done on that basis.
+
+        # Create/update entities for devices found in the latest scan
         for mac, device_data in devices.items():
             # Only create entities for devices that have been seen as active at least once
             if device_data.get("active") or device_data.get("last_seen"):
-                unique_id = f"{entry.entry_id}_{mac.replace(':', '_')}"
                 # Only add entities that have not been created yet
                 found = False
-                haentities = async_add_entities.__self__.entities
                 for entitykey in haentities:
                     entity = haentities[entitykey]
-                    if getattr(entity, "_attr_unique_id", None) == unique_id:
+                    if getattr(entity, "mac_address", None) == mac:
                         # Update entities that have been added to Home Assistant
                         entity._device_data = device_data
                         entity._attr_name = device_data.get("name") or f"Device {mac}"
@@ -76,7 +87,7 @@ async def async_setup_entry(
                     # Skip creating new entity if not allowed, unless the entity
                     # already exists in the Home Assistant entity registry.
                     existing_entity_id = entity_registry.async_get_entity_id(
-                        "device_tracker", DOMAIN, unique_id
+                        "device_tracker", DOMAIN, mac
                     )
                     if not allow_new_devices and existing_entity_id is None:
                         # Skip creating new entity when not allowed and no existing registry entry
@@ -87,12 +98,65 @@ async def async_setup_entry(
                     entities.append(entity)
                     created_entities.add(mac)
 
+        # Recreate entities present in the entity registry for this config entry
+        # even if the device is currently absent from the scan (e.g. right after
+        # a HA restart, before the device has reconnected). Skip disabled entries.
+        #
+        # NOTE: also track MACs queued in *this* invocation (from the loop
+        # above) so we don't create a second, duplicate entity for a device
+        # that is both in the current scan AND already in the entity registry
+        # - `haentities` only reflects entities already added to hass in a
+        # *previous* call, not ones still pending in the local `entities` list.
+        queued_macs = {e.mac_address for e in entities}
+        for reg_entity in list(entity_registry.entities.values()):
+            # Skip disabled entities in the registry (user/automation disabled)
+            if getattr(reg_entity, "disabled_by", None) is not None:
+                continue
+
+            if (
+                reg_entity.domain != "device_tracker"
+                or reg_entity.platform != DOMAIN
+                or getattr(reg_entity, "config_entry_id", None) != entry.entry_id
+            ):
+                continue
+
+            # unique_id IS the MAC address for a ScannerEntity - see note above.
+            reg_mac = reg_entity.unique_id
+            if not reg_mac:
+                continue
+
+            if reg_mac in queued_macs:
+                continue
+
+            # If an entity object is already present, skip
+            already_present = any(
+                getattr(haentities[entitykey], "mac_address", None) == reg_mac
+                for entitykey in haentities
+            )
+            if already_present:
+                continue
+
+            # Create entity with available device data (may be empty/offline)
+            device_data = devices.get(reg_mac)
+            if not device_data:
+                # The device is offline upon restart.
+                # Create an empty dict but retrieve the historical name from the registry
+                # to prevent it from being overwritten with the "Device {mac}" fallback.
+                device_data = {}
+                if getattr(reg_entity, "original_name", None):
+                    device_data["name"] = reg_entity.original_name
+
+            entity = ZteDeviceTrackerEntity(coordinator, entry, reg_mac, dict(device_data))
+            entities.append(entity)
+            queued_macs.add(reg_mac)
+            created_entities.add(reg_mac)
+
         if entities:
             async_add_entities(entities)
-            # Asignar área a las nuevas entidades
+            # Assign area to the new entities
             for entity in entities:
                 entity_id = entity_registry.async_get_entity_id(
-                    "device_tracker", DOMAIN, entity._attr_unique_id
+                    "device_tracker", DOMAIN, entity.mac_address
                 )
                 if entity_id and area_id:
                     entity_registry.async_update_entity(entity_id, area_id=area_id)
@@ -104,7 +168,12 @@ async def async_setup_entry(
         entity_registry = er.async_get(hass)
         for entity_id, entity in entity_registry.entities.items():
             if entity.domain == "device_tracker" and entity.platform == DOMAIN:
-                mac = entity.unique_id.split("_")[-1].replace("_", ":")
+                # unique_id IS the MAC address for a ScannerEntity - see note
+                # in _async_add_entities above. No entry_id prefix is ever
+                # involved, regardless of what _attr_unique_id was set to.
+                mac = entity.unique_id
+                if not mac:
+                    continue
                 devices = (
                     coordinator.data.get("devices", {}) if coordinator.data else {}
                 )
@@ -141,10 +210,19 @@ class ZteDeviceTrackerEntity(CoordinatorEntity, ScannerEntity):
         self._entry = entry
         self._mac = mac
         self._device_data = device_data
-
-        # Generate unique ID and name
-        self._attr_unique_id = f"{entry.entry_id}_{mac.replace(':', '_')}"
         self._attr_name = device_data.get("name") or f"Device {mac}"
+
+        # NOTE: we intentionally do NOT set self._attr_unique_id here. HA's
+        # ScannerEntity base class (homeassistant/components/device_tracker/
+        # config_entry.py) overrides the `unique_id` property to always
+        # return `self.mac_address` - any `_attr_unique_id` we set would be
+        # silently ignored. The real unique_id is the `mac_address` property
+        # below, i.e. `self._mac` as-is (whatever case the router reports).
+        _LOGGER.debug(
+            "ZteDeviceTrackerEntity created: mac=%s (effective unique_id, "
+            "per ScannerEntity.unique_id -> mac_address)",
+            mac,
+        )
 
         # Device info is provided via property below
 


### PR DESCRIPTION
On HA reboot, entities not connected to the router are no longer provided by the integration. If the 'register new devices' flag is disabled, those entities will never come back online. This solves the problem by re-adding entities already known to the integration on reboot, reading them from the registry if they are not present in the router's response at that moment.