### PR TITLE
Add ZTE F8748 (DIGI Portugal) with WAN traffic counters

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ For ZTE mesh networks (e.g. F6600P Controller + H196A Agent), enable **Mesh topo
 | ZTE F6645P    |     F6645P      |    ✅    |
 | ZTE F680    |      F680      |    ✅    |
 | ZTE F6600P  |     F6600P      |    ✅    |
+| ZTE F8748   |      F8748      |    ✅    |
 | ZTE H169A     |      H169A      |    ✅    |
 | ZTE H2640     |      H2640      |    ✅    |
 | ZTE H288A     |      H288A      |    ✅    |
@@ -164,6 +165,8 @@ For ZTE mesh networks (e.g. F6600P Controller + H196A Agent), enable **Mesh topo
 | ZTE SR7410 (ZTE BE7200 Pro+)   |      SR7410      |    ✅    |
 
 > **Note**: This integration may work with additional ZTE router models. Try one of the above parameter values to test compatibility.
+
+> **F8748 note**: Verified on a unit provided by **DIGI Portugal** (firmware `V3.0.10P2N4`, hardware `V3.0.03`). It uses the same web-console endpoints as the F6640 family, so the `F6640` logic works unchanged. DIGI units in other countries (e.g. Spain, Romania) are likely to behave the same. This is an ISP-locked GPON ONT; F8748 units from other providers or bought retail may expose additional pages/data, which we were not able to confirm.
 
 ## 🚀 Installation
 

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ For ZTE mesh networks (e.g. F6600P Controller + H196A Agent), enable **Mesh topo
 
 > **Note**: This integration may work with additional ZTE router models. Try one of the above parameter values to test compatibility.
 
-> **F8748 note**: Verified on a unit provided by **DIGI Portugal** (firmware `V3.0.10P2N4`, hardware `V3.0.03`). It uses the same web-console endpoints as the F6640 family, so the `F6640` logic works unchanged. DIGI units in other countries (e.g. Spain, Romania) are likely to behave the same. This is an ISP-locked GPON ONT; F8748 units from other providers or bought retail may expose additional pages/data, which we were not able to confirm.
+> **F8748 note**: Verified on a unit provided by **DIGI Portugal** (firmware `V3.0.10P2N4`, hardware `V3.0.03`). It shares the F6640 web-console endpoints, and is defined as a distinct model because this firmware additionally exposes **WAN traffic counters** in `wan_internetstatus_lua.lua`. When the model is `F8748`, the integration parses those into extra router-status attributes: `WAN_rx_bytes`, `WAN_tx_bytes`, `WAN_rx_packets`, `WAN_tx_packets`, `WAN_rx_errors`, `WAN_tx_errors`. This is gated to `F8748` so other F6640-family routers are unaffected (we could not confirm they populate the same fields). DIGI units in other countries (e.g. Spain, Romania) are likely identical; F8748 units from other providers or bought retail may expose additional pages/data we could not confirm.
 
 ## 🚀 Installation
 

--- a/custom_components/zte_tracker/zteclient/zte_client.py
+++ b/custom_components/zte_tracker/zteclient/zte_client.py
@@ -91,6 +91,9 @@ _MODELS["E2631"] = _MODELS["E2631"]
 _MODELS["SR7410"] = _MODELS["E2631"]
 _MODELS["SR7110"] = _MODELS["E2631"]
 _MODELS["F680"] = _MODELS["F6640"]
+# ZTE F8748 (GPON ONT). Confirmed working on a DIGI Portugal unit, fw V3.0.10P2N4.
+# Uses the same web-console endpoints as the F6640 family.
+_MODELS["F8748"] = _MODELS["F6640"]
 
 
 class zteClient:

--- a/custom_components/zte_tracker/zteclient/zte_client.py
+++ b/custom_components/zte_tracker/zteclient/zte_client.py
@@ -91,9 +91,16 @@ _MODELS["E2631"] = _MODELS["E2631"]
 _MODELS["SR7410"] = _MODELS["E2631"]
 _MODELS["SR7110"] = _MODELS["E2631"]
 _MODELS["F680"] = _MODELS["F6640"]
-# ZTE F8748 (GPON ONT). Confirmed working on a DIGI Portugal unit, fw V3.0.10P2N4.
-# Uses the same web-console endpoints as the F6640 family.
-_MODELS["F8748"] = _MODELS["F6640"]
+# ZTE F8748 (GPON ONT) - DIGI Portugal ISP unit, firmware V3.0.10P2N4.
+# Defined as a distinct model (not a plain F6640 alias): it shares the F6640
+# web-console endpoints, but this firmware also exposes WAN traffic counters
+# (RxBytes/TxBytes/packets/errors) in wan_internetstatus_lua.lua. The
+# "parse_wan_traffic" flag enables extracting those without assuming other
+# F6640-family routers populate the same fields.
+_MODELS["F8748"] = {
+    **_MODELS["F6640"],
+    "parse_wan_traffic": True,
+}
 
 
 class zteClient:
@@ -719,6 +726,30 @@ class zteClient:
                         wan_attrs["WAN_remain_leasetime"] = int(pvalue)
                     elif pname == "ConnStatus":
                         wan_attrs["WAN_connected"] = pvalue == "Connected"
+            # WAN traffic counters. Model-gated: only enabled for firmwares
+            # confirmed (via web-console capture) to expose these fields, since
+            # other F6640-family routers may not populate them. On the F8748 the
+            # counters live on the routed/PPPoE instance, which may differ from
+            # the status instance above, so scan all instances.
+            if self.paths.get("parse_wan_traffic"):
+                traffic_map = {
+                    "RxBytes": "WAN_rx_bytes",
+                    "TxBytes": "WAN_tx_bytes",
+                    "RxPackets": "WAN_rx_packets",
+                    "TxPackets": "WAN_tx_packets",
+                    "ErrorsReceived": "WAN_rx_errors",
+                    "ErrorsSent": "WAN_tx_errors",
+                }
+                for inst in instances:
+                    for i in range(0, len(inst) // 2):
+                        pn = inst[i * 2].text
+                        pv = inst[i * 2 + 1].text
+                        if (
+                            pn in traffic_map
+                            and pv is not None
+                            and pv.strip().lstrip("-").isdigit()
+                        ):
+                            wan_attrs[traffic_map[pn]] = int(pv)
         except Exception as ex:
             _LOGGER.warning(f"Failed to fetch WAN status: {ex}")
         return wan_attrs


### PR DESCRIPTION
## Summary

Adds the **ZTE F8748** (GPON ONT) as a **distinct model** (not a plain F6640 alias). It shares the F6640 web-console endpoints, but this firmware additionally exposes **WAN traffic counters**, which the integration now parses for this model.

## What it does
- Registers `F8748` as its own `_MODELS` entry (spread of `F6640` + a `parse_wan_traffic` flag).
- `get_wan_status()` extracts, when `parse_wan_traffic` is set, the counters from `wan_internetstatus_lua.lua` into router-status attributes:
  `WAN_rx_bytes`, `WAN_tx_bytes`, `WAN_rx_packets`, `WAN_tx_packets`, `WAN_rx_errors`, `WAN_tx_errors`.
- **Gated to `F8748`** so other F6640-family routers are unaffected (we could not confirm they populate these fields).

## How the data was found
Reverse-engineered the router's web console (headless browser so the router's own JS runs). The login uses the standard `login_token` + `sha256(password + token)` flow and the data pages are the same `*_lua.lua` scripts as F6640. On the F8748, `wan_internetstatus_lua.lua` returns the routed/PPPoE instance with `RxBytes`/`TxBytes`/`RxPackets`/`TxPackets`/`ErrorsReceived`/`ErrorsSent`.

## Verification
Tested on a real F8748 from **DIGI Portugal** (fw `V3.0.10P2N4`, hw `V3.0.03`): device tracking, WAN status, CPU/memory, reboot, and the new WAN traffic counters all read correctly.

## Notes for other users
- Verified on a **DIGI Portugal** unit; DIGI units in Spain/Romania are likely identical.
- ISP-locked GPON ONT: F8748s from other providers or bought retail may expose additional pages/data we could not confirm.
- Console is single-session (login preemption), consistent with other ZTE models.

## Changes
- `zteclient/zte_client.py`: distinct `F8748` model + `parse_wan_traffic` extraction in `get_wan_status()`
- `README.md`: F8748 row + provider/firmware/traffic note